### PR TITLE
Add ReleaseBuildOnly configuration

### DIFF
--- a/Starwatch.Core/Starwatch.Core.csproj
+++ b/Starwatch.Core/Starwatch.Core.csproj
@@ -6,6 +6,7 @@
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
+    <Configurations>Debug;Release;ReleaseBuildOnly</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Starwatch.sln
+++ b/Starwatch.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2003
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Starwatch", "Starwatch\Starwatch.csproj", "{DB510F70-84E8-420B-8C5F-1AE33C9942DD}"
 EndProject
@@ -11,16 +11,21 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ReleaseBuildOnly|Any CPU = ReleaseBuildOnly|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.ReleaseBuildOnly|Any CPU.ActiveCfg = ReleaseBuildOnly|Any CPU
+		{DB510F70-84E8-420B-8C5F-1AE33C9942DD}.ReleaseBuildOnly|Any CPU.Build.0 = ReleaseBuildOnly|Any CPU
 		{58FCB696-1DE3-421F-A472-D71143F3A16D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{58FCB696-1DE3-421F-A472-D71143F3A16D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58FCB696-1DE3-421F-A472-D71143F3A16D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58FCB696-1DE3-421F-A472-D71143F3A16D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58FCB696-1DE3-421F-A472-D71143F3A16D}.ReleaseBuildOnly|Any CPU.ActiveCfg = ReleaseBuildOnly|Any CPU
+		{58FCB696-1DE3-421F-A472-D71143F3A16D}.ReleaseBuildOnly|Any CPU.Build.0 = ReleaseBuildOnly|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Starwatch/Starwatch.csproj
+++ b/Starwatch/Starwatch.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
+    <Configurations>Debug;Release;ReleaseBuildOnly</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Gets files by themselves with no config JSON to make release builds safer to package.